### PR TITLE
phantomjs setTimeout to onLoadFinish instead

### DIFF
--- a/src/Spatie/Browsershot/Browsershot.php
+++ b/src/Spatie/Browsershot/Browsershot.php
@@ -287,10 +287,14 @@ class Browsershot
                         document.head.insertBefore(style, document.head.firstChild);
                     });
                 }
-                window.setTimeout(function(){
+                
+                var renderOut = function() {
                     page.render('{$targetFile}');
                     phantom.exit();
-                }, {$this->timeout});
+                };
+                
+                page.onLoadFinished = renderOut.call();
+                page.onResourceTimeout = renderOut.call();
             });
         ";
     }


### PR DESCRIPTION
Since we are already using resourceTimeout, it's marginally faster to trigger render on `page.onLoadFinished` instead of waiting for a timeout, while `page.onResourceTimeout` will also trigger the same render.

This will have a big impact even on the default timeout (5000) when the page completes loading before reaching the default timeout.
